### PR TITLE
Respect the :checked value for the hidden field named delete.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "django-formset",
   "description": "A jQuery plugin that allows you dynamically add new forms to a rendered django formset.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "homepage": "https://github.com/wearespindle/django-formset",
   "author": {

--- a/src/django-formset.js
+++ b/src/django-formset.js
@@ -264,7 +264,7 @@ class Formset {
         let deleteInput = formsetElement.find('input:checkbox[id $= "-DELETE"]');
         // Replace default formset checkboxes with hidden fields.
         if (deleteInput.length) {
-            deleteInput.before(`<input type="hidden" name="${deleteInput.attr('name')}" id="${deleteInput.attr('id')}" />`);
+            deleteInput.before(`<input type="hidden" name="${deleteInput.attr('name')}" id="${deleteInput.attr('id')}" + ` +  (deleteInput.is(':checked') ? ' value="on"' : '') + "/>");
             deleteInput.remove();
         }
     }


### PR DESCRIPTION
If the delete checkbox is checked, the `replaceCheckboxes` does not respect this.
Now it does.